### PR TITLE
Fix mix of :entity-attr/:entity-id to specify identifying attributes

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -29,7 +29,7 @@
          '[boot.git :refer [last-commit]])
 
 (def +project+ 'workflo/brahman)
-(def +version+ "0.3.0-SNAPSHOT")
+(def +version+ "0.4.0-SNAPSHOT")
 
 (bootlaces! +version+ :dont-modify-paths? true)
 

--- a/src/workflo/brahman/backends/datascript.cljc
+++ b/src/workflo/brahman/backends/datascript.cljc
@@ -128,11 +128,8 @@
 
 (defn query-derived-attr
   [conn env attr query entity]
-  (let [entity-attr (or (:entity-attr env) :db/id)]
-    (d/q (:query attr)
-         @conn
-         entity-attr (entity entity-attr)
-         query)))
+  (let [entity-id (or (:entity-id env) :db/id)]
+    (d/q (:query attr) @conn (entity-id entity) query)))
 
 (defn- identifying-model-attr
   [model]

--- a/src/workflo/brahman/model.cljc
+++ b/src/workflo/brahman/model.cljc
@@ -313,7 +313,7 @@
          model->attrs       default-model->attrs
          model->joins       default-model->joins
          validate           default-validate
-         entity-id          identity
+         entity-id          :db/id
          query-store        default-query-store
          query-derived-attr default-query-derived-attr
          query-link         default-query-link

--- a/test/workflo/brahman/test/backends/datascript.clj
+++ b/test/workflo/brahman/test/backends/datascript.clj
@@ -17,8 +17,8 @@
           :derived-attrs [{:name  :friend-count
                            :store :datascript
                            :query '[:find (count ?f) .
-                                    :in $ ?eattr ?eval
-                                    :where [?u ?eattr ?eval]
+                                    :in $ ?n
+                                    :where [?u :user/name ?n]
                                            [?u :user/friend ?f]]}]}
    :post {:name          :post
           :schema        {:author {[:ref :one] :user}
@@ -104,6 +104,7 @@
                  {:models             (vals +models+)
                   :model->attrs       bds/model->attrs
                   :model->joins       bds/model->joins
+                  :entity-id          :user/name
                   :install-schemas    (partial install-schemas conn)
                   :query-derived-attr (partial query-derived-attr conn)
                   :query-store        (partial query-store conn)})
@@ -134,8 +135,7 @@
                 (bm/query users [:user/name
                                  :user/email
                                  :user/friend-count]
-                          {:fetch-one?  true
-                           :entity-attr :user/name}
+                          {:fetch-one? true}
                           '[[?e :user/name "Jeff"]])))
          (is (= {:user/email        "linda@linda.org"
                  :user/post         [{:post/title "Linda's post"}]
@@ -146,8 +146,7 @@
                            :user/friend-count
                            {:user/post [:post/title]}
                            {:user/friend [:user/name]}]
-                          {:fetch-one?  true
-                           :entity-attr :user/name}
+                          {:fetch-one? true}
                           '[[?e :user/name "Linda"]]))))))
 
 (deftest fetching-many-entities-from-datascript-works
@@ -156,6 +155,7 @@
                  {:models             (vals +models+)
                   :model->attrs       bds/model->attrs
                   :model->joins       bds/model->joins
+                  :entity-id          :user/name
                   :install-schemas    (partial install-schemas conn)
                   :query-derived-attr (partial query-derived-attr conn)
                   :query-store        (partial query-store conn)})
@@ -196,6 +196,7 @@
                  {:models             (vals +models+)
                   :model->attrs       bds/model->attrs
                   :model->joins       bds/model->joins
+                  :entity-id          :user/name
                   ;; :model->links       bds/model->links
                   :install-schemas    (partial install-schemas conn)
                   :query-derived-attr (partial query-derived-attr conn)


### PR DESCRIPTION
This is a minor fix that is needed to make derived attributes work with DataScript.
