### PR TITLE
Fix default-validate to take three arguments and return nil

### DIFF
--- a/src/workflo/brahman/model.cljc
+++ b/src/workflo/brahman/model.cljc
@@ -264,8 +264,8 @@
   {})
 
 (defn- default-validate
-  [model data]
-  true)
+  [model validation data]
+  nil)
 
 (defn- default-query-store
   [env query {:keys [inputs extra]}]


### PR DESCRIPTION
In this case nil stands for no errors. If validate fails it either
throws an exception or returns a collection of errors.
